### PR TITLE
Namepet refactor

### DIFF
--- a/coreword.js
+++ b/coreword.js
@@ -17,18 +17,18 @@ const pkey = function pkey(skey) {
 	return ubye(etils.computePublicKey(ustr(skey)));
 };
 
- // Return the EIP-191 personal message digest of message.
- // https://docs.ethers.io/v5/api/utils/hashing/#utils-hashMessage
+// Return the EIP-191 personal message digest of message.
+// https://docs.ethers.io/v5/api/utils/hashing/#utils-hashMessage
 const eip191Digest = function eip191Digest(msg) {
 	verifyIns(msg);
-	return ubye( etils.hashMessage(ustr(msg)) );
+	return ubye(etils.hashMessage(ustr(msg)));
 };
 
 // Return EIP-191 signature.
 // https://docs.ethers.io/v5/api/signer/#Signer-signMessage
 const eip191Sign = async function eip191Sign(msg, key) {
 	verifyIns(msg, key);
-	return ubye( await (new Wallet(ustr(key))).signMessage(msg) );
+	return ubye(await (new Wallet(ustr(key))).signMessage(msg));
 };
 
 // Return public key as is, only if public key is verified to have (EIP191) signed message. Throw an error otherwise.

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.1",
   "type": "module",
   "dependencies": {
-    "ethers": "^5.6.8",
-    "js-sha3": "^0.8.0",
-    "rlp": "^3.0.0"
+    "ethers": "^5.6.8"
   },
   "devDependencies": {
     "tapzero": "^0.6.1"

--- a/test.js
+++ b/test.js
@@ -1,33 +1,21 @@
-import { test } from 'tapzero'
+import { test } from 'tapzero';
 
-import { roll, scry, sign } from './coreword.js'
+import { scry, sign, ubye, pkey } from './coreword.js';
 
-import { utils as etils } from 'ethers'
+const sk = ubye("0x309a49dcda67245af724a05ff081b0c5d24ec0b87a1393d940de6c1dd60f45a3");
+const pk = pkey(sk);
 
-const ubyte = etils.toUtf8Bytes
-const sk_txt = "0x309a49dcda67245af724a05ff081b0c5d24ec0b87a1393d940de6c1dd60f45a3"
-const sk = ubyte(sk_txt)
-const pk_txt = etils.computePublicKey(sk_txt)
-const pk = ubyte(pk_txt)
-
-test('roll', t=>{
-    t.ok(roll([]))
-})
-
-test('scry', async _=>{
-    const verify = msg=> test(
-        String.raw`TEST: ${msg}`,
-        async t=> t.equal(
-            scry(
-                ubyte(msg),
-                pk,
-                await sign(ubyte(msg), sk)
-            ),
-            pk
-        )
-    )
-    verify("What is real? That which is irreplacable.")
-    verify("")
-    verify("\\n")
-    verify(String.raw`"\\u0024"`)
-})
+test('scry', async _ => {
+  const verify = msg_str => test(
+    String.raw`${msg_str}:`,
+    async t => {
+      const msg = ubye(msg_str);
+      const sig = await sign(msg, sk);
+      t.equal(scry(msg, pk, sig), pk);
+    }
+  );
+  verify("What is real? That which is irreplacable.");
+  verify("");
+  verify("\\n");
+  verify(String.raw`"\\u0024"`);
+});

--- a/test.js
+++ b/test.js
@@ -1,17 +1,17 @@
 import { test } from 'tapzero';
 
-import { scry, sign, ubye, pkey } from './coreword.js';
+import { eip191Scry, eip191Sign, ubye, pkey } from './coreword.js';
 
 const sk = ubye("0x309a49dcda67245af724a05ff081b0c5d24ec0b87a1393d940de6c1dd60f45a3");
 const pk = pkey(sk);
 
-test('scry', async _ => {
+test('eip191Scry', async _ => {
   const verify = msg_str => test(
     String.raw`${msg_str}:`,
     async t => {
       const msg = ubye(msg_str);
-      const sig = await sign(msg, sk);
-      t.equal(scry(msg, pk, sig), pk);
+      const sig = await eip191Sign(msg, sk);
+      t.equal(eip191Scry(msg, pk, sig), pk);
     }
   );
   verify("What is real? That which is irreplacable.");

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ test('eip191Scry', async _ => {
     async t => {
       const msg = ubye(msg_str);
       const sig = await eip191Sign(msg, sk);
-      t.equal(eip191Scry(msg, pk, sig), pk);
+      t.deepEqual(eip191Scry(msg, pk, sig), pk);
     }
   );
   verify("What is real? That which is irreplacable.");


### PR DESCRIPTION
- refactor functions to take and return `Uint8Array`
- export more of etils
- emphasize eip191 in signing and verifying+ec-recovery
- use `deepEqual` for the test, which now compares in `Uint8Array`